### PR TITLE
Initialize variables if needed

### DIFF
--- a/after/syntax/markdown/gfm.vim
+++ b/after/syntax/markdown/gfm.vim
@@ -1,3 +1,7 @@
+if !exists('g:loaded_gfm_syntax')
+  runtime plugin/gfm_syntax.vim
+endif
+
 if !g:gfm_syntax_enable_always && index(g:gfm_syntax_enable_filetypes, &l:filetype) == -1
     finish
 endif


### PR DESCRIPTION
Some situations, `after/syntax/markdown/gfm.vim` is loaded before `plugin/gfm_syntax.vim`.

To reproduce with Docker:

```dockerfile
FROM thinca/vim:v8.2.2850

RUN mkdir -p ~/.vim \
 && wget --quiet --output-document - \
    "https://github.com/rhysd/vim-gfm-syntax/archive/c0ff9e4994d4e79c8d5edf963094518dceea2623.tar.gz" | \
    tar xz -C ~/.vim --strip-components=1 \
 && echo "syntax enable" > ~/.vimrc

CMD ["foo.md"]
```

This PR fixes this problem.