### PR TITLE
FIX: :+1: is not concealed with the corresponding emoji

### DIFF
--- a/after/syntax/markdown/gfm.vim
+++ b/after/syntax/markdown/gfm.vim
@@ -34,7 +34,7 @@ endif
 " :dog:
 if g:gfm_syntax_highlight_emoji
     if g:gfm_syntax_emoji_conceal && has('conceal')
-        exe 'syn iskeyword '.&iskeyword.',-,:'
+        exe 'syn iskeyword '.&iskeyword.',+,-,:'
         call gfm_syntax#emoji#apply_conceal()
     else
         syn match githubFlavoredMarkdownEmoji ":[[:alnum:]_+-]\+:" display


### PR DESCRIPTION
Because `:syn iskeyword` only gets `:` and `-` added, but not the `+` that's part of the `+1` emoji name.